### PR TITLE
POST /shops でURLがInstagramのものか判定できるロジックの実装

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -78,7 +78,7 @@ class ShopsController < ApplicationController
   private
  
   def shop_params
-    params.permit(:name, :url, :station_name, :address, :tel, :memo, :review, :is_instagram, :is_ai_generated)
+    params.permit(:name, :url, :station_name, :address, :tel, :memo, :review, :is_ai_generated)
   end
 
   def delete_params

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -1,6 +1,8 @@
 class Shop < ApplicationRecord
     belongs_to :station, optional: true
 
+    before_validation :set_instagram_flag
+
     validates :name, presence: { message: "ショップ名は必須です" }
     validates :is_ai_generated, inclusion: { in: [true, false], message: "AI生成フラグは必須です" }
     validates :is_instagram, inclusion: { in: [true, false], message: "Instagramフラグは必須です" }
@@ -8,4 +10,16 @@ class Shop < ApplicationRecord
     def station_name
         self.station&.name
     end
+    
+    
+    private
+
+  def set_instagram_flag
+    if url.present? && url.include?("instagram.com")
+      self.is_instagram = true
+    else
+      self.is_instagram = false
+    end
+  end
+
 end

--- a/doc/components/schemas/create.yaml
+++ b/doc/components/schemas/create.yaml
@@ -37,8 +37,6 @@ ManualCreate:
     review:
       type: integer
       example: 5
-    is_instagram:
-      type: boolean
     is_ai_generated:
       type: boolean
       description: ai入力かどうか

--- a/doc/paths/shops.yaml
+++ b/doc/paths/shops.yaml
@@ -94,7 +94,6 @@
                 tel: "042-201-1478"
                 memo: "美味しいワインバルです"
                 review: 5
-                is_instagram: true # または false
                 is_ai_generated: false
             autoInputExample:
               summary: 自動入力の例 (Instagramから情報取得)


### PR DESCRIPTION
## 概要

- ユーザーが登録したショップ情報のURLがInstagramの場合は、Shop.is_instagramをtrueにする
- 設計を修正し、is_instagramがなくても400系のエラーを出さないように修正
　- 合わせてis_instagramをリクエストパラメータに含まれないようにも修正
- controller側で、リクエストされたURLがInstagramかどうか判定するロジックを追加
　- Shop.is_instagramを適切に登録できるようにする

## 実装
- ManualCreateからis_instagramを削除
- shopコントローラーのリクエストパラメータからis_instagramを削除
- shopモデルにinstagramのurlか判定するロジックを追加

## 動作確認

- Instagramのurlを入力した時
- 新規作成したレコードid=42
```ruby
app(dev)> Shop.find_by(name:"id:42").id
  Shop Load (0.9ms)  SELECT `shops`.* FROM `shops` WHERE `shops`.`name` = 'id:42' LIMIT 1 /*application='App'*/
=> 42
```

- postmanで検証
```json
{
    "data": {
        "id": 42,
        "name": "id:42",
        "address": null,
        "tel": null,
        "memo": null,
        "review": 0,
        "is_instagram": true,
        "station_name": null
    },
    "success": true
}
```

- Instagramではないurlを入力した時
- 新規作成したレコードid=43
```ruby
app(dev)> Shop.find_by(name:"id:43").id
  Shop Load (1.0ms)  SELECT `shops`.* FROM `shops` WHERE `shops`.`name` = 'id:43' LIMIT 1 /*application='App'*/
=> 43
```

- postmanで検証
```json
{
    "data": {
        "id": 43,
        "name": "id:43",
        "address": null,
        "tel": null,
        "memo": null,
        "review": 0,
        "is_instagram": false,
        "station_name": null
    },
    "success": true
}
```

- urlを入力していない時
- 新規作成したレコードid=44
```ruby
app(dev)> Shop.find_by(name:"id:44").id
  Shop Load (0.8ms)  SELECT `shops`.* FROM `shops` WHERE `shops`.`name` = 'id:44' LIMIT 1 /*application='App'*/
=> 44
```

- postmanで検証
```json
{
    "data": {
        "id": 44,
        "name": "id:44",
        "address": null,
        "tel": null,
        "memo": null,
        "review": 0,
        "is_instagram": false,
        "station_name": null
    },
    "success": true
}
```